### PR TITLE
Allow to override the nginx.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ RUN mkdir /var/log/nginx \
 
 EXPOSE 80 443
 
-CMD ["dockerize","-stdout","/var/log/nginx/access.log","-stderr","/var/log/nginx/error.log","/usr/sbin/nginx","-g","daemon off;"]
+COPY run.sh /run.sh
+CMD ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following instructions create an NGINX container that provides a static page
 
 1. Create an NGINX Docker container with an nginx.conf file that has LDAP authentication enabled. You can find a sample [nginx.conf](https://github.com/g17/nginx-ldap/blob/master/config/basic/nginx.conf) file in the config folder that provides the static default NGINX welcome page.
 
-		docker run --name nginx --link ldap:ldap -d -v `pwd`/config/nginx.conf:/etc/nginx/nginx.conf:ro -p 80:80 h3nrik/nginx-ldap
+		docker run --name nginx --link ldap:ldap -d -v `pwd`/config/nginx.conf:/nginx.conf:ro -p 80:80 h3nrik/nginx-ldap
 
 2. When you now access the NGINX server via port 80 you will get an authentication dialog. The user name for the test user is *test* and the password is *t3st*.
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+if test ! -e /nginx.conf; then
+    cp /etc/nginx/nginx.conf /nginx.conf
+fi
+dockerize -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log /usr/sbin/nginx -c /nginx.conf -g "daemon off;"


### PR DESCRIPTION
On certain setups it's not possible to bind a file over an existing one.
This commits makes it possible by using a non-existing /nginx.conf
file and copy over the default one if it doesn't exist.

The run.sh command takes care of that.
