### PR TITLE
Install openssl >= 1.0.2 from jessie-backports for validating LDAP ssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ MAINTAINER Henrik Sachse <t3x7m3@posteo.de>
 
 ENV NGINX_VERSION release-1.11.3
 
+# Use jessie-backports for openssl >= 1.0.2
+# This is required by nginx-auth-ldap when ssl_check_cert is turned on.
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
+	&& echo 'deb http://ftp.debian.org/debian/ jessie-backports main' > /etc/apt/sources.list.d/backports.list \
 	&& apt-get update \
-	&& apt-get install -y \
+	&& apt-get install -t jessie-backports -y \
 		ca-certificates \
 		git \
 		gcc \


### PR DESCRIPTION
Without this version of SSL, if you turn on SSL certificate verification you get this error:

```
nginx: [emerg] http_auth_ldap: 'ssl_cert_check': cannot verify remote certificate's domain name because your version of OpenSSL is too old. Please install OpenSSL >= 1.02 and recompile nginx.
```

With this change openssl 1.0.2 is installed from backports and the same config works with `ssl_check_cert on;`